### PR TITLE
Config fix

### DIFF
--- a/src/main/resources/bullet_dsl_defaults.yaml
+++ b/src/main/resources/bullet_dsl_defaults.yaml
@@ -19,7 +19,7 @@ bullet.dsl.connector.kafka.start.at.end.enable: false
 # prefix removed. The properties below are required.
 # Properties found at: https://kafka.apache.org/20/javadoc/org/apache/kafka/clients/consumer/ConsumerConfig.html
 bullet.dsl.connector.kafka.bootstrap.servers: "localhost:9092"
-bullet.dsl.connector.kafka.group.id:
+bullet.dsl.connector.kafka.group.id: "bullet-consumer-group"
 bullet.dsl.connector.kafka.key.deserializer: "org.apache.kafka.common.serialization.StringDeserializer"
 bullet.dsl.connector.kafka.value.deserializer: "org.apache.kafka.common.serialization.ByteArrayDeserializer"
 

--- a/src/test/java/com/yahoo/bullet/dsl/BulletDSLConfigTest.java
+++ b/src/test/java/com/yahoo/bullet/dsl/BulletDSLConfigTest.java
@@ -17,6 +17,9 @@ public class BulletDSLConfigTest {
 
         config = new BulletDSLConfig("test_config.yaml");
         Assert.assertEquals(config.get(BulletDSLConfig.RECORD_PROVIDER_CLASS_NAME), "com.yahoo.bullet.record.SimpleBulletRecordProvider");
+
+        config = new BulletDSLConfig("src/main/resources/bullet_dsl_defaults.yaml");
+        Assert.assertEquals(config.get(BulletDSLConfig.CONNECTOR_KAFKA_GROUP_ID), "bullet-consumer-group");
     }
 
     @Test(expectedExceptions = IllegalStateException.class)


### PR DESCRIPTION
Bug in default yaml causing no args constructor to fail. This is a problem for bullet-spark since it seems the no args constructor is used during kryo deserialization...