### PR TITLE
JsonBulletRecordConverter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,10 +33,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <bullet.core.version>1.1.0</bullet.core.version>
+        <bullet.core.version>1.2.0</bullet.core.version>
         <kafka.clients.version>2.3.0</kafka.clients.version>
         <pulsar.client.version>2.2.1</pulsar.client.version>
-        <avro.version>1.7.7</avro.version>
+        <avro.version>1.9.2</avro.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>

--- a/src/main/java/com/yahoo/bullet/dsl/converter/BulletRecordConverter.java
+++ b/src/main/java/com/yahoo/bullet/dsl/converter/BulletRecordConverter.java
@@ -29,8 +29,9 @@ import java.util.Optional;
 
 /**
  * BulletRecordConverter is used to convert objects into BulletRecords. Converters should extend this class and expect
- * configuration though {@link BulletDSLConfig}. If a {@link BulletRecordSchema} is provided, values will be typed casted
- * during conversion. If a schema is not provided, the level of type-checking is left to the implementation.
+ * configuration though {@link BulletDSLConfig}. If a {@link BulletRecordSchema} is provided, and type-checking is
+ * enabled, the converter will check if values match their types in the schema and throw if they do not. If a schema is
+ * not provided, the level of type-checking is left to the implementation.
  */
 public abstract class BulletRecordConverter implements Serializable {
 

--- a/src/main/java/com/yahoo/bullet/dsl/converter/JsonBulletRecordConverter.java
+++ b/src/main/java/com/yahoo/bullet/dsl/converter/JsonBulletRecordConverter.java
@@ -18,7 +18,7 @@ import java.util.Map;
  * JsonBulletRecordConverter is used to convert {@link String} json to {@link BulletRecord}. It uses Gson to convert
  * the json to a map which is then converted to a {@link BulletRecord}.
  * <br><br>
- * If a schema is not specified, the json effectively flattened without any regard to type-safety.
+ * If a schema is not specified, the json is effectively flattened without any regard to type-safety.
  */
 public class JsonBulletRecordConverter extends MapBulletRecordConverter {
 

--- a/src/main/java/com/yahoo/bullet/dsl/converter/JsonBulletRecordConverter.java
+++ b/src/main/java/com/yahoo/bullet/dsl/converter/JsonBulletRecordConverter.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright 2021, Yahoo Inc.
+ *  Licensed under the terms of the Apache License, Version 2.0.
+ *  See the LICENSE file associated with the project for terms.
+ */
+package com.yahoo.bullet.dsl.converter;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.yahoo.bullet.common.BulletConfig;
+import com.yahoo.bullet.dsl.BulletDSLException;
+import com.yahoo.bullet.record.BulletRecord;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * JsonBulletRecordConverter is used to convert {@link String} json to {@link BulletRecord}. It uses Gson to convert
+ * the json to a map which is then converted to a {@link BulletRecord}.
+ * <br><br>
+ * If a schema is not specified, the json effectively flattened without any regard to type-safety.
+ */
+public class JsonBulletRecordConverter extends MapBulletRecordConverter {
+
+    private static final long serialVersionUID = 8262353280806978091L;
+    private static final Gson GSON = new Gson();
+
+    public JsonBulletRecordConverter() throws BulletDSLException {
+        super();
+    }
+
+    public JsonBulletRecordConverter(String schema) throws BulletDSLException {
+        super(schema);
+    }
+
+    public JsonBulletRecordConverter(BulletConfig bulletConfig) throws BulletDSLException {
+        super(bulletConfig);
+    }
+
+    @Override
+    public BulletRecord convert(Object object, BulletRecord record) throws BulletDSLException {
+        String json = (String) object;
+        Map<String, Serializable> map = GSON.fromJson(json, new TypeToken<Map<String, Object>>(){ }.getType());
+        return super.convert(map, record);
+    }
+}

--- a/src/main/java/com/yahoo/bullet/dsl/converter/JsonBulletRecordConverter.java
+++ b/src/main/java/com/yahoo/bullet/dsl/converter/JsonBulletRecordConverter.java
@@ -40,7 +40,7 @@ public class JsonBulletRecordConverter extends MapBulletRecordConverter {
     @Override
     public BulletRecord convert(Object object, BulletRecord record) throws BulletDSLException {
         String json = (String) object;
-        Map<String, Serializable> map = GSON.fromJson(json, new TypeToken<Map<String, Object>>(){ }.getType());
+        Map<String, Serializable> map = GSON.fromJson(json, new TypeToken<Map<String, Object>>() { }.getType());
         return super.convert(map, record);
     }
 }

--- a/src/main/resources/bullet_dsl_defaults.yaml
+++ b/src/main/resources/bullet_dsl_defaults.yaml
@@ -1,7 +1,7 @@
 ###### BulletConnector properties
 
 # The classpath to the BulletConnector to use
-bullet.dsl.connector.class.name: "com.yahoo.bullet.dsl.connector.KafkaConnector"
+bullet.dsl.connector.class.name:
 # The read timeout duration in ms
 bullet.dsl.connector.read.timeout.ms: 0
 # Whether or not to asynchronously commit messages
@@ -53,7 +53,7 @@ bullet.dsl.connector.pulsar.consumer.subscriptionType: "Shared"
 ###### BulletRecordConverter properties
 
 # The classpath to the BulletRecordConverter to use
-bullet.dsl.converter.class.name: "com.yahoo.bullet.dsl.converter.AvroBulletRecordConverter"
+bullet.dsl.converter.class.name:
 # The path to the schema file to use
 bullet.dsl.converter.schema.file: ""
 # Should type checking be performed for fields with type in the schema. It is useful to make sure that the types in

--- a/src/test/java/com/yahoo/bullet/dsl/converter/JsonBulletRecordConverterTest.java
+++ b/src/test/java/com/yahoo/bullet/dsl/converter/JsonBulletRecordConverterTest.java
@@ -1,0 +1,206 @@
+/*
+ *  Copyright 2021, Yahoo Inc.
+ *  Licensed under the terms of the Apache License, Version 2.0.
+ *  See the LICENSE file associated with the project for terms.
+ */
+package com.yahoo.bullet.dsl.converter;
+
+import com.yahoo.bullet.dsl.BulletDSLConfig;
+import com.yahoo.bullet.dsl.BulletDSLException;
+import com.yahoo.bullet.record.BulletRecord;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class JsonBulletRecordConverterTest {
+
+    @Test(expectedExceptions = BulletDSLException.class)
+    public void testBuildWithSchemaErrors() throws Exception {
+        new JsonBulletRecordConverter("schemas/empty.json");
+    }
+
+    @Test
+    public void testConvertWithoutSchema() throws Exception {
+        JsonBulletRecordConverter recordConverter = new JsonBulletRecordConverter();
+
+        String json = "{\"myBool\":true,\"myInt\":123,\"myLong\":456,\"myFloat\":7.89,\"myDouble\":0.12,\"myString\":\"345\"}";
+
+        BulletRecord record = recordConverter.convert(json);
+
+        // Converts numbers as double without schema because of gson
+        Assert.assertEquals(record.typedGet("myBool").getValue(), true);
+        Assert.assertEquals(record.typedGet("myInt").getValue(), 123.0);
+        Assert.assertEquals(record.typedGet("myLong").getValue(), 456.0);
+        Assert.assertEquals(record.typedGet("myFloat").getValue(), 7.89);
+        Assert.assertEquals(record.typedGet("myDouble").getValue(), 0.12);
+        Assert.assertEquals(record.typedGet("myString").getValue(), "345");
+        Assert.assertFalse(record.hasField("dne"));
+
+        // does not add null fields
+        Assert.assertEquals(record.fieldCount(), 6);
+    }
+
+    @Test
+    public void testConvertWithoutSchemaUsingConfigConstructor() throws Exception {
+        BulletDSLConfig config = new BulletDSLConfig();
+        JsonBulletRecordConverter recordConverter = new JsonBulletRecordConverter(config);
+
+        String json = "{\"myBool\":true,\"myInt\":123,\"myLong\":456,\"myFloat\":7.89,\"myDouble\":0.12,\"myString\":\"345\",\"myNull\":null,\"myNull2\":null}";
+
+        BulletRecord record = recordConverter.convert(json);
+
+        // Converts numbers as double without schema because of gson
+        Assert.assertEquals(record.typedGet("myBool").getValue(), true);
+        Assert.assertEquals(record.typedGet("myInt").getValue(), 123.0);
+        Assert.assertEquals(record.typedGet("myLong").getValue(), 456.0);
+        Assert.assertEquals(record.typedGet("myFloat").getValue(), 7.89);
+        Assert.assertEquals(record.typedGet("myDouble").getValue(), 0.12);
+        Assert.assertEquals(record.typedGet("myString").getValue(), "345");
+        Assert.assertFalse(record.hasField("dne"));
+
+        // does not add null fields
+        Assert.assertEquals(record.fieldCount(), 6);
+    }
+
+    @Test
+    public void testConvertWithSchema() throws Exception {
+        JsonBulletRecordConverter recordConverter = new JsonBulletRecordConverter("schemas/all.json");
+
+        String json = "{\"myBool\":true,\"myInt\":123,\"myLong\":456,\"myFloat\":7.89,\"myDouble\":0.12,\"myString\":\"345\",\"dne\":0}";
+
+        BulletRecord record = recordConverter.convert(json);
+
+        Assert.assertEquals(record.typedGet("myBool").getValue(), true);
+        Assert.assertEquals(record.typedGet("myInt").getValue(), 123.0);
+        Assert.assertEquals(record.typedGet("myLong").getValue(), 456.0);
+        Assert.assertEquals(record.typedGet("myFloat").getValue(), 7.89);
+        Assert.assertEquals(record.typedGet("myDouble").getValue(), 0.12);
+        Assert.assertEquals(record.typedGet("myString").getValue(), "345");
+        Assert.assertFalse(record.hasField("dne"));
+
+        // does not add null for missing fields
+        Assert.assertEquals(record.fieldCount(), 6);
+    }
+    @Test
+    public void testConvertRecord() throws Exception {
+        JsonBulletRecordConverter recordConverter = new JsonBulletRecordConverter("schemas/record1.json");
+
+        String json = "{\"data\":{\"myBool\":true,\"myInt\":123,\"myLong\":456,\"myFloat\":7.89,\"myDouble\":0.12,\"myString\":\"345\",\"myNull\":null,\"myNull2\":null}}";
+
+        // flattens "data"
+        BulletRecord record = recordConverter.convert(json);
+
+        Assert.assertEquals(record.typedGet("myBool").getValue(), true);
+        Assert.assertEquals(record.typedGet("myInt").getValue(), 123.0);
+        Assert.assertEquals(record.typedGet("myLong").getValue(), 456.0);
+        Assert.assertEquals(record.typedGet("myFloat").getValue(), 7.89);
+        Assert.assertEquals(record.typedGet("myDouble").getValue(), 0.12);
+        Assert.assertEquals(record.typedGet("myString").getValue(), "345");
+
+        // does not add null fields
+        Assert.assertEquals(record.fieldCount(), 6);
+    }
+
+    @Test
+    public void testNestedConvertRecord() throws Exception {
+        JsonBulletRecordConverter recordConverter = new JsonBulletRecordConverter("schemas/record2.json");
+
+        Map<String, Object> mapRecord = new HashMap<>();
+        Map<String, Object> data = new HashMap<>();
+
+        mapRecord.put("data", data);
+
+        String json = "{\"data\":{}}";
+
+        // tries to flatten "data.aaa.bbb" but aaa is missing
+        BulletRecord record = recordConverter.convert(json);
+
+        Assert.assertEquals(record.fieldCount(), 0);
+
+        // tries to flatten "data.aaa.bbb" but bbb is missing
+        json = "{\"data\":{\"aaa\":{}}}";
+
+        record = recordConverter.convert(json);
+
+        Assert.assertEquals(record.fieldCount(), 0);
+
+        // flattens "data.aaa.bbb" but bbb is empty
+        json = "{\"data\":{\"aaa\":{\"bbb\":{}}}}";
+
+        record = recordConverter.convert(json);
+
+        Assert.assertEquals(record.fieldCount(), 0);
+
+        // flattens "data.aaa.bbb"
+        json = "{\"data\":{\"aaa\":{\"bbb\":{\"myBool\":true,\"myInt\":123,\"myLong\":456,\"myFloat\":7.89,\"myDouble\":0.12,\"myString\":\"345\"}}}}";
+
+        record = recordConverter.convert(json);
+
+        Assert.assertEquals(record.typedGet("myBool").getValue(), true);
+        Assert.assertEquals(record.typedGet("myInt").getValue(), 123.0);
+        Assert.assertEquals(record.typedGet("myLong").getValue(), 456.0);
+        Assert.assertEquals(record.typedGet("myFloat").getValue(), 7.89);
+        Assert.assertEquals(record.typedGet("myDouble").getValue(), 0.12);
+        Assert.assertEquals(record.typedGet("myString").getValue(), "345");
+    }
+
+    @Test
+    public void testExtractFromList() throws Exception {
+        JsonBulletRecordConverter recordConverter = new JsonBulletRecordConverter("schemas/dummy.json");
+
+        String json = "{\"myIntList\":[0,1,2,3,4]}";
+
+        BulletRecord record = recordConverter.convert(json);
+
+        Assert.assertEquals(record.typedGet("bbb").getValue(), 2.0);
+    }
+
+    @Test
+    public void testMaps() throws Exception {
+        String json = "{\"myLongMapMap\":{\"k\":{\"l\":9}},\"myStringMapMap\":{\"q\":{\"r\":\"12\"}},\"myBoolMap\":{\"a\":false},\"myDoubleMapMap\":{\"o\":{\"p\":11.0}},\"myDoubleMap\":{\"e\":5.0},\"myFloatMapMap\":{\"m\":{\"n\":10.0}},\"myLongMap\":{\"c\":3},\"myFloatMap\":{\"d\":4.0},\"myBoolMapMap\":{\"g\":{\"h\":true}},\"myIntMapMap\":{\"i\":{\"j\":8}},\"myIntMap\":{\"b\":2},\"myStringMap\":{\"f\":\"6\"}}";
+
+        // Loads schema using class loader
+        JsonBulletRecordConverter recordConverter = new JsonBulletRecordConverter("schemas/all.json");
+        BulletRecord record = recordConverter.convert(json);
+
+        Assert.assertEquals(record.typedGet("myBoolMap").getValue(), Collections.singletonMap("a", false));
+        Assert.assertEquals(record.typedGet("myIntMap").getValue(), Collections.singletonMap("b", 2.0));
+        Assert.assertEquals(record.typedGet("myLongMap").getValue(), Collections.singletonMap("c", 3.0));
+        Assert.assertEquals(record.typedGet("myFloatMap").getValue(), Collections.singletonMap("d", 4.0));
+        Assert.assertEquals(record.typedGet("myDoubleMap").getValue(), Collections.singletonMap("e", 5.0));
+        Assert.assertEquals(record.typedGet("myStringMap").getValue(), Collections.singletonMap("f", "6"));
+        Assert.assertEquals(record.typedGet("myBoolMapMap").getValue(), Collections.singletonMap("g", Collections.singletonMap("h", true)));
+        Assert.assertEquals(record.typedGet("myIntMapMap").getValue(), Collections.singletonMap("i", Collections.singletonMap("j", 8.0)));
+        Assert.assertEquals(record.typedGet("myLongMapMap").getValue(), Collections.singletonMap("k", Collections.singletonMap("l", 9.0)));
+        Assert.assertEquals(record.typedGet("myFloatMapMap").getValue(), Collections.singletonMap("m", Collections.singletonMap("n", 10.0)));
+        Assert.assertEquals(record.typedGet("myDoubleMapMap").getValue(), Collections.singletonMap("o", Collections.singletonMap("p", 11.0)));
+        Assert.assertEquals(record.typedGet("myStringMapMap").getValue(), Collections.singletonMap("q", Collections.singletonMap("r", "12")));
+        Assert.assertFalse(record.hasField("dne"));
+    }
+
+    @Test
+    public void testLists() throws Exception {
+        String json = "{\"myLongMapList\":[{\"u\":21}],\"myFloatList\":[16.0],\"myFloatMapList\":[{\"v\":22.0}],\"myIntList\":[14],\"myIntMapList\":[{\"t\":20}],\"myLongList\":[15],\"myBoolList\":[false],\"myBoolMapList\":[{\"s\":true}],\"myStringMapList\":[{\"x\":\"24\"}],\"myDoubleMapList\":[{\"w\":23.0}],\"myStringList\":[\"18\"],\"myDoubleList\":[17.0]}";
+
+        // Loads schema using class loader
+        JsonBulletRecordConverter recordConverter = new JsonBulletRecordConverter("schemas/all.json");
+        BulletRecord record = recordConverter.convert(json);
+
+        Assert.assertEquals(record.typedGet("myBoolList").getValue(), Collections.singletonList(false));
+        Assert.assertEquals(record.typedGet("myIntList").getValue(), Collections.singletonList(14.0));
+        Assert.assertEquals(record.typedGet("myLongList").getValue(), Collections.singletonList(15.0));
+        Assert.assertEquals(record.typedGet("myFloatList").getValue(), Collections.singletonList(16.0));
+        Assert.assertEquals(record.typedGet("myDoubleList").getValue(), Collections.singletonList(17.0));
+        Assert.assertEquals(record.typedGet("myStringList").getValue(), Collections.singletonList("18"));
+        Assert.assertEquals(record.typedGet("myBoolMapList").getValue(), Collections.singletonList(Collections.singletonMap("s", true)));
+        Assert.assertEquals(record.typedGet("myIntMapList").getValue(), Collections.singletonList(Collections.singletonMap("t", 20.0)));
+        Assert.assertEquals(record.typedGet("myLongMapList").getValue(), Collections.singletonList(Collections.singletonMap("u", 21.0)));
+        Assert.assertEquals(record.typedGet("myFloatMapList").getValue(), Collections.singletonList(Collections.singletonMap("v", 22.0)));
+        Assert.assertEquals(record.typedGet("myDoubleMapList").getValue(), Collections.singletonList(Collections.singletonMap("w", 23.0)));
+        Assert.assertEquals(record.typedGet("myStringMapList").getValue(), Collections.singletonList(Collections.singletonMap("x", "24")));
+        Assert.assertFalse(record.hasField("dne"));
+    }
+}


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

A couple things that I was considering and couldn't make a decision on:

One, there's an annoying behavior where json numbers will be converted to double. I looked into getting around this by having the base converter force cast types when a schema is provided. For the most part, this works rather nicely but sometimes breaks if it can't force cast something (which a try-catch solves). This is pretty much the case with empty maps/lists that end up as unknown map/list and causes extra work to be done to create a new empty map/list, so I'm not really happy w/ that at the moment. 

That also brings up the second issue which is that if we have "shouldTypeCheck" enabled, any empty maps/lists will not pass the type check since they end up as unknown maps/lists; I'm not sure if we want that. It would be great if empty maps/lists counted as valid maps/lists of whatever primitive and similar for complex ones. 

I also wonder if we might want a "shouldTypeCast" as a separate option from "shouldTypeCheck" should we want to type cast at all. 

For now, this PR doesn't have any of the above considerations...