### PR TITLE
Add missing KafkaConnector property

### DIFF
--- a/src/main/resources/bullet_dsl_defaults.yaml
+++ b/src/main/resources/bullet_dsl_defaults.yaml
@@ -22,6 +22,7 @@ bullet.dsl.connector.kafka.bootstrap.servers: "localhost:9092"
 bullet.dsl.connector.kafka.group.id: "bullet-consumer-group"
 bullet.dsl.connector.kafka.key.deserializer: "org.apache.kafka.common.serialization.StringDeserializer"
 bullet.dsl.connector.kafka.value.deserializer: "org.apache.kafka.common.serialization.ByteArrayDeserializer"
+bullet.dsl.connector.kafka.enable.auto.commit: true
 
 ###### PulsarConnector properties
 


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.


Observeded the following warning in my logs:

```plain
[WARN ] 2021-07-03 06:14:22,623 com.yahoo.bullet.common.Validator - Key: bullet.dsl.connector.kafka.enable.auto.commit had an invalid value: null. Using default: true
```

This PR adds the missing entry in the default config file.

(The [config file used for testing](https://github.com/bullet-db/bullet-dsl/blob/master/src/test/resources/test_connector_config.yaml#L15) does contain it already)